### PR TITLE
Restrict deployment to main branch 

### DIFF
--- a/.github/workflows/build-data.yaml
+++ b/.github/workflows/build-data.yaml
@@ -2,6 +2,8 @@ name: "Rebuild Data"
 on:
   schedule:
     - cron: "33 17 * * 4" # every Thursday at 5:45PM UTC == 12:33PM EST
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       regenerate:
@@ -37,7 +39,7 @@ jobs:
       email: '${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com'
       regenerate: ${{ inputs.regenerate || false }}
       build: ${{ inputs.build || 'both' }}
-      publish: ${{ inputs.publish || github.event_name != 'workflow_dispatch'}}
+      publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets:
       id: 'none'
       key: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -23,7 +23,7 @@ jobs:
       name: '${{ github.event.repository.name }}'
       slug: '${{ github.event.repository.owner.login }}'
       email: '${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com'
-      publish: ${{ inputs.publish || github.event_name == "push" }}
+      publish: ${{ inputs.publish || github.event_name == 'push' }}
     secrets:
       id: 'none'
       key: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -8,6 +8,9 @@ on:
         required: false
         default: true
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: write
@@ -20,7 +23,7 @@ jobs:
       name: '${{ github.event.repository.name }}'
       slug: '${{ github.event.repository.owner.login }}'
       email: '${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com'
-      publish: ${{ inputs.publish || github.event_name != 'workflow_dispatch'}}
+      publish: ${{ inputs.publish || github.event_name == "push" }}
     secrets:
       id: 'none'
       key: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should prevent shenanigans where we accidentally push when testing 🙈 


 - restrict deployments to main branch only
 - add explicit PR dry-run testing by fixing the `publish` key to trigger only on the appropriate input