### PR TITLE
add predevals config copied from flusight dashboard

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -1,0 +1,257 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.0/config_schema.json
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+  - interval_coverage_50
+  - interval_coverage_95
+  relative_metrics:
+  - wis
+  - ae_median
+  baseline: FluSight-baseline
+  disaggregate_by:
+  - location
+  - reference_date
+  - horizon
+  - target_end_date
+eval_sets:
+- eval_set_name: Full season
+  round_filters:
+    min: '2024-11-30'
+  task_filters:
+    location:
+    - "01"
+    - "02"
+    - "04"
+    - "05"
+    - "06"
+    - "08"
+    - "09"
+    - "10"
+    - "11"
+    - "12"
+    - "13"
+    - "15"
+    - "16"
+    - "17"
+    - "18"
+    - "19"
+    - "20"
+    - "21"
+    - "22"
+    - "23"
+    - "24"
+    - "25"
+    - "26"
+    - "27"
+    - "28"
+    - "29"
+    - "30"
+    - "31"
+    - "32"
+    - "33"
+    - "34"
+    - "35"
+    - "36"
+    - "37"
+    - "38"
+    - "39"
+    - "40"
+    - "41"
+    - "42"
+    - "44"
+    - "45"
+    - "46"
+    - "47"
+    - "48"
+    - "49"
+    - "50"
+    - "51"
+    - "53"
+    - "54"
+    - "55"
+    - "56"
+    - "72"
+    horizon:
+    - 0
+    - 1
+    - 2
+    - 3
+    reference_date:
+    - "2024-11-30"
+    - "2024-12-07"
+    - "2024-12-14"
+    - "2024-12-21"
+    - "2024-12-28"
+    - "2025-01-04"
+    - "2025-01-11"
+    - "2025-01-18"
+    - "2025-02-01"
+    - "2025-02-08"
+    - "2025-02-15"
+    - "2025-02-22"
+    - "2025-03-01"
+    - "2025-03-08"
+    - "2025-03-15"
+    - "2025-03-22"
+    - "2025-03-29"
+    - "2025-04-05"
+    - "2025-04-12"
+    - "2025-04-19"
+    - "2025-04-26"
+    - "2025-05-03"
+    - "2025-05-10"
+    - "2025-05-17"
+    - "2025-05-24"
+    - "2025-05-31"
+- eval_set_name: Last 4 weeks
+  round_filters:
+    min: '2024-11-30'
+    n_last: 5
+  task_filters:
+    location:
+    - "01"
+    - "02"
+    - "04"
+    - "05"
+    - "06"
+    - "08"
+    - "09"
+    - "10"
+    - "11"
+    - "12"
+    - "13"
+    - "15"
+    - "16"
+    - "17"
+    - "18"
+    - "19"
+    - "20"
+    - "21"
+    - "22"
+    - "23"
+    - "24"
+    - "25"
+    - "26"
+    - "27"
+    - "28"
+    - "29"
+    - "30"
+    - "31"
+    - "32"
+    - "33"
+    - "34"
+    - "35"
+    - "36"
+    - "37"
+    - "38"
+    - "39"
+    - "40"
+    - "41"
+    - "42"
+    - "44"
+    - "45"
+    - "46"
+    - "47"
+    - "48"
+    - "49"
+    - "50"
+    - "51"
+    - "53"
+    - "54"
+    - "55"
+    - "56"
+    - "72"
+    horizon:
+    - 0
+    - 1
+    - 2
+    - 3
+    reference_date:
+    - "2024-11-30"
+    - "2024-12-07"
+    - "2024-12-14"
+    - "2024-12-21"
+    - "2024-12-28"
+    - "2025-01-04"
+    - "2025-01-11"
+    - "2025-01-18"
+    - "2025-02-01"
+    - "2025-02-08"
+    - "2025-02-15"
+    - "2025-02-22"
+    - "2025-03-01"
+    - "2025-03-08"
+    - "2025-03-15"
+    - "2025-03-22"
+    - "2025-03-29"
+    - "2025-04-05"
+    - "2025-04-12"
+    - "2025-04-19"
+    - "2025-04-26"
+    - "2025-05-03"
+    - "2025-05-10"
+    - "2025-05-17"
+    - "2025-05-24"
+    - "2025-05-31"
+task_id_text:
+  location:
+    US: United States
+    '01': Alabama
+    '02': Alaska
+    '04': Arizona
+    '05': Arkansas
+    '06': California
+    '08': Colorado
+    '09': Connecticut
+    '10': Delaware
+    '11': District of Columbia
+    '12': Florida
+    '13': Georgia
+    '15': Hawaii
+    '16': Idaho
+    '17': Illinois
+    '18': Indiana
+    '19': Iowa
+    '20': Kansas
+    '21': Kentucky
+    '22': Louisiana
+    '23': Maine
+    '24': Maryland
+    '25': Massachusetts
+    '26': Michigan
+    '27': Minnesota
+    '28': Mississippi
+    '29': Missouri
+    '30': Montana
+    '31': Nebraska
+    '32': Nevada
+    '33': New Hampshire
+    '34': New Jersey
+    '35': New Mexico
+    '36': New York
+    '37': North Carolina
+    '38': North Dakota
+    '39': Ohio
+    '40': Oklahoma
+    '41': Oregon
+    '42': Pennsylvania
+    '44': Rhode Island
+    '45': South Carolina
+    '46': South Dakota
+    '47': Tennessee
+    '48': Texas
+    '49': Utah
+    '50': Vermont
+    '51': Virginia
+    '53': Washington
+    '54': West Virginia
+    '55': Wisconsin
+    '56': Wyoming
+    '60': American Samoa
+    '66': Guam
+    '69': Northern Mariana Islands
+    '72': Puerto Rico
+    '74': U.S. Minor Outlying Islands
+    '78': Virgin Islands

--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -255,3 +255,4 @@ task_id_text:
     '72': Puerto Rico
     '74': U.S. Minor Outlying Islands
     '78': Virgin Islands
+


### PR DESCRIPTION
At the present moment, this will not work on a repo created from this template because we attempt to pull data from an `oracle-data` branch, which does not exist here.  But soon, we will expect to pull oracle data from the hub itself, so I think it makes sense to add a starter file here.  I will add stuff to the docs saying to delete this if users don't want an evaluations page for the dashboard.