### PR TITLE
fix forecast/target build bug

### DIFF
--- a/.github/workflows/build-data.yaml
+++ b/.github/workflows/build-data.yaml
@@ -43,7 +43,7 @@ jobs:
       slug: '${{ github.event.repository.owner.login }}'
       email: '${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com'
       regenerate: ${{ inputs.regenerate || false }}
-      build: ${{ inputs.build || 'both' }}
+      build: ${{ inputs.data || 'both' }}
       publish: ${{ inputs.publish || github.event_name == 'schedule' || github.event_name == 'push' }}
     secrets:
       id: 'none'


### PR DESCRIPTION
This fixes a bug where the option to build targets or forecasts was not being respected mainly because I was passing the _wrong parameter name_, which ended up being empty, which is falsy, and thus went to the default.