### PR TITLE
Bump hubPredEvalsData schema to v1.1.0

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -1,4 +1,4 @@
-schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
 rounds_idx: 0
 targets:
 - target_id: wk inc flu hosp


### PR DESCRIPTION
## Summary

Bumps the `schema_version` in `predevals-config.yml` from `v1.0.1` to `v1.1.0`, the latest available schema in [hubPredEvalsData](https://github.com/hubverse-org/hubPredEvalsData/tree/main/inst/schema), in preparation for releasing the new dashboard features.

## Changes

- `predevals-config.yml`: `schema_version` → `.../inst/schema/v1.1.0/config_schema.json`

## Notes

This PR is **ready for merging once the release process is complete**. Hold the merge until the new dashboard features are released.

⚠️ The evals data build will **not succeed until the new hubPredEvalsData docker image is published**. Do not merge until that image is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)