### PR TITLE
Switch template to dashboard-test-hub & remove deprecated target_data_file_name

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -2,6 +2,12 @@ schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/
 rounds_idx: 0
 targets:
 - target_id: wk inc flu hosp
+  transform:
+    fun: log_shift
+    label: log
+    args:
+      offset: 1
+    append: true
   metrics:
   - wis
   - ae_median
@@ -10,18 +16,43 @@ targets:
   relative_metrics:
   - wis
   - ae_median
-  baseline: FluSight-baseline
+  baseline: Flusight-baseline
+  disaggregate_by:
+  - location
+  - reference_date
+  - horizon
+  - target_end_date
+- target_id: wk inc flu death
+  metrics:
+  - wis
+  - ae_median
+  - interval_coverage_50
+  - interval_coverage_95
+  relative_metrics:
+  - wis
+  - ae_median
+  baseline: Flusight-baseline
+  disaggregate_by:
+  - location
+  - reference_date
+  - horizon
+  - target_end_date
+- target_id: wk flu hosp rate category
+  metrics:
+  - log_score
+  - rps
   disaggregate_by:
   - location
   - reference_date
   - horizon
   - target_end_date
 eval_sets:
-- eval_set_name: Full season
+- eval_set_name: All rounds
   round_filters:
-    min: '2024-11-30'
+    min: '2022-10-22'
   task_filters:
     location:
+    - "US"
     - "01"
     - "02"
     - "04"
@@ -80,122 +111,10 @@ eval_sets:
     - 2
     - 3
     reference_date:
-    - "2024-11-30"
-    - "2024-12-07"
-    - "2024-12-14"
-    - "2024-12-21"
-    - "2024-12-28"
-    - "2025-01-04"
-    - "2025-01-11"
-    - "2025-01-18"
-    - "2025-02-01"
-    - "2025-02-08"
-    - "2025-02-15"
-    - "2025-02-22"
-    - "2025-03-01"
-    - "2025-03-08"
-    - "2025-03-15"
-    - "2025-03-22"
-    - "2025-03-29"
-    - "2025-04-05"
-    - "2025-04-12"
-    - "2025-04-19"
-    - "2025-04-26"
-    - "2025-05-03"
-    - "2025-05-10"
-    - "2025-05-17"
-    - "2025-05-24"
-    - "2025-05-31"
-- eval_set_name: Last 4 weeks
-  round_filters:
-    min: '2024-11-30'
-    n_last: 5
-  task_filters:
-    location:
-    - "01"
-    - "02"
-    - "04"
-    - "05"
-    - "06"
-    - "08"
-    - "09"
-    - "10"
-    - "11"
-    - "12"
-    - "13"
-    - "15"
-    - "16"
-    - "17"
-    - "18"
-    - "19"
-    - "20"
-    - "21"
-    - "22"
-    - "23"
-    - "24"
-    - "25"
-    - "26"
-    - "27"
-    - "28"
-    - "29"
-    - "30"
-    - "31"
-    - "32"
-    - "33"
-    - "34"
-    - "35"
-    - "36"
-    - "37"
-    - "38"
-    - "39"
-    - "40"
-    - "41"
-    - "42"
-    - "44"
-    - "45"
-    - "46"
-    - "47"
-    - "48"
-    - "49"
-    - "50"
-    - "51"
-    - "53"
-    - "54"
-    - "55"
-    - "56"
-    - "72"
-    horizon:
-    - 0
-    - 1
-    - 2
-    - 3
-    reference_date:
-    - "2024-11-30"
-    - "2024-12-07"
-    - "2024-12-14"
-    - "2024-12-21"
-    - "2024-12-28"
-    - "2025-01-04"
-    - "2025-01-11"
-    - "2025-01-18"
-    - "2025-02-01"
-    - "2025-02-08"
-    - "2025-02-15"
-    - "2025-02-22"
-    - "2025-03-01"
-    - "2025-03-08"
-    - "2025-03-15"
-    - "2025-03-22"
-    - "2025-03-29"
-    - "2025-04-05"
-    - "2025-04-12"
-    - "2025-04-19"
-    - "2025-04-26"
-    - "2025-05-03"
-    - "2025-05-10"
-    - "2025-05-17"
-    - "2025-05-24"
-    - "2025-05-31"
+    - "2022-10-22"
+    - "2022-11-19"
+    - "2022-12-17"
+    - "2023-01-14"
 task_id_text:
   location:
     US: United States
@@ -250,10 +169,4 @@ task_id_text:
     '54': West Virginia
     '55': Wisconsin
     '56': Wyoming
-    '60': American Samoa
-    '66': Guam
-    '69': Northern Mariana Islands
     '72': Puerto Rico
-    '74': U.S. Minor Outlying Islands
-    '78': Virgin Islands
-

--- a/predtimechart-config.yml
+++ b/predtimechart-config.yml
@@ -3,9 +3,8 @@ rounds_idx: 0
 reference_date_col_name: 'reference_date'
 target_date_col_name: 'target_end_date'
 horizon_col_name: 'horizon'
-initial_checked_models: ['UMass-flusion', 'UMass-trends_ensemble']
+initial_checked_models: ['Flusight-baseline', 'MOBS-GLEAM_FLUH']
 disclaimer: "This is a disclaimer. It presents important information for your stakeholders."
-target_data_file_name: 'target-hospital-admissions.csv'
 task_id_text:
   location: # location,location_name
     "US": "United States"
@@ -60,9 +59,4 @@ task_id_text:
     "54": "West Virginia"
     "55": "Wisconsin"
     "56": "Wyoming"
-    "60": "American Samoa"
-    "66": "Guam"
-    "69": "Northern Mariana Islands"
     "72": "Puerto Rico"
-    "74": "U.S. Minor Outlying Islands"
-    "78": "Virgin Islands"

--- a/site-config.yml
+++ b/site-config.yml
@@ -1,6 +1,6 @@
 ---
-hub: "cdcepi/FluSight-forecast-hub/"
-title: "Example Hub Dashboard Website"
+hub: "hubverse-org/dashboard-test-hub/"
+title: "Dashboard Test Hub"
 pages:
   - "about.md"
   - "data.qmd"


### PR DESCRIPTION
Switches the template's data source from the large `cdcepi/FluSight-forecast-hub` to the smaller `hubverse-org/dashboard-test-hub` for much faster builds and demos, mirroring [`dashboard-test-hub-dashboard`](https://github.com/hubverse-org/dashboard-test-hub-dashboard). Also drops the deprecated `target_data_file_name` field.

Closes #19
Closes #16

## Changes

### `site-config.yml`
- `hub:` → `hubverse-org/dashboard-test-hub/`
- `title:` → `"Dashboard Test Hub"`

### `predtimechart-config.yml`
- `initial_checked_models` → `Flusight-baseline`, `MOBS-GLEAM_FLUH`
- Trimmed `task_id_text` locations to match the test hub (ends at `72` Puerto Rico; removed territories `60/66/69/74/78`)
- **Removed `target_data_file_name`** (#16) — deprecated; the test hub uses standard hubverse time-series target data (`target-data/time-series.csv`)

### `predevals-config.yml`
- Three targets matching the test hub's `tasks.json`: `wk inc flu hosp` (with `log_shift` transform), `wk inc flu death`, and `wk flu hosp rate category` (`log_score`/`rps`)
- `baseline` → `Flusight-baseline`
- Single `All rounds` eval set, `min: 2022-10-22`, 4 monthly `reference_date`s, locations trimmed to `72`
- Stays on schema `v1.1.0` (consistent with #18)

## Deliberate exclusions / retained items
- **Did not** bring across the reference dashboard's `html: include-after-body: resources/build-footer.html` — that footer is specific to that repo and out of scope for a general template (per #19).
- **Kept `data.qmd`** — to be updated separately for the Python `hubdata` package (#20).
- **Kept `pages/img/` and `about.md`** — the example team images are referenced by `about.md`; removing them would break that example page.
- **Kept the `disclaimer` field** in `predtimechart-config.yml` — it demonstrates a template feature and is independent of the data-source swap.

## Notes
- Verified models, targets, locations, and reference dates against the live `dashboard-test-hub` `tasks.json` and `target-data/`.
- End-to-end demo of cloud data access (the data page) still depends on mirroring the test hub to S3 (hubverse-org/dashboard-test-hub#6), tracked separately under #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)